### PR TITLE
데이터베이스 환경셋팅 (#1)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,6 @@
 {
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "endOfLine": "auto",
+  "semi": true
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,8 +1,11 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { MysqlModule } from './mysql/mysql.module';
+import { LoggersModule } from './loggers/loggers.module';
 import * as Joi from 'joi';
+import { LoggersMiddleware } from './loggers/loggers.middleware';
 
 @Module({
   imports: [
@@ -10,11 +13,20 @@ import * as Joi from 'joi';
       envFilePath: '.env',
       isGlobal: true,
       validationSchema: Joi.object({
+        NODE_ENV: Joi.string().valid('development', 'production').required(),
         SERVER_PORT: Joi.number().default(3000).required(),
       }),
     }),
+    MysqlModule,
+    LoggersModule,
   ],
   controllers: [AppController],
   providers: [AppService],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    if (process.env.NODE_ENV !== 'production') {
+      consumer.apply(LoggersMiddleware).forRoutes('*');
+    }
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,6 +15,12 @@ import { LoggersMiddleware } from './loggers/loggers.middleware';
       validationSchema: Joi.object({
         NODE_ENV: Joi.string().valid('development', 'production').required(),
         SERVER_PORT: Joi.number().default(3000).required(),
+        /* DATABASE (RDBMS) */
+        DB_HOST: Joi.string().required(),
+        DB_PORT: Joi.number().required(),
+        DB_USERNAME: Joi.string().required(),
+        DB_PASSWORD: Joi.string().required(),
+        DB_DATABASE: Joi.string().required(),
       }),
     }),
     MysqlModule,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -18,9 +18,9 @@ import { LoggersMiddleware } from './loggers/loggers.middleware';
         /* DATABASE (RDBMS) */
         DB_HOST: Joi.string().required(),
         DB_PORT: Joi.number().required(),
-        DB_USERNAME: Joi.string().required(),
-        DB_PASSWORD: Joi.string().required(),
-        DB_DATABASE: Joi.string().required(),
+        DB_USER: Joi.string().required(),
+        DB_PWD: Joi.string().required(),
+        DB_NAME: Joi.string().required(),
       }),
     }),
     MysqlModule,

--- a/src/loggers/loggers.middleware.ts
+++ b/src/loggers/loggers.middleware.ts
@@ -1,0 +1,19 @@
+import { Request, Response, NextFunction } from 'express';
+import { Injectable, Logger, NestMiddleware } from '@nestjs/common';
+
+@Injectable()
+export class LoggersMiddleware implements NestMiddleware {
+  private logger = new Logger('HTTP');
+
+  use(req: Request, res: Response, next: NextFunction) {
+    const { ip, method, originalUrl } = req;
+    const userAgent = req.get('user-agent') || '';
+    res.on('finish', () => {
+      const { statusCode } = res;
+      this.logger.log(
+        `${method} ${statusCode} - ${originalUrl} - ${ip} - ${userAgent}`,
+      );
+    });
+    next();
+  }
+}

--- a/src/loggers/loggers.module.ts
+++ b/src/loggers/loggers.module.ts
@@ -1,0 +1,4 @@
+import { Module } from '@nestjs/common';
+
+@Module({})
+export class LoggersModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,11 @@
+import { Logger, ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  const PORT = process.env.SERVER_PORT || 3000;
 
   const swaggerConfig = new DocumentBuilder()
     .setTitle('Toy-Squad Server Swagger')
@@ -14,8 +16,26 @@ async function bootstrap() {
 
   const swaggerDocument = SwaggerModule.createDocument(app, swaggerConfig);
 
-  SwaggerModule.setup('api', app, swaggerDocument);
+  /**
+   * https://localhost:3000/swagger 브라우저 창에 입력시 스웨거가 생성됩니다.
+   */
+  SwaggerModule.setup('swagger', app, swaggerDocument);
 
-  await app.listen(process.env.SERVER_PORT);
+  // 파이프 추가
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      transform: true,
+    }),
+  );
+
+  // swagger을 제외한 모든 API는 맨앞에 '/api'를 붙인다.
+  app.setGlobalPrefix('/api');
+
+  await app.listen(PORT, () => {
+    new Logger(`MODE ${process.env.NODE_ENV.toUpperCase()}`).localInstance.log(
+      `APP LISTEN ON PORT: ${PORT}`,
+    );
+  });
 }
 bootstrap();

--- a/src/mysql/mysql.module.ts
+++ b/src/mysql/mysql.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { MysqlService } from './mysql.service';
+
+@Module({
+  providers: [MysqlService]
+})
+export class MysqlModule {}

--- a/src/mysql/mysql.module.ts
+++ b/src/mysql/mysql.module.ts
@@ -1,7 +1,5 @@
 import { Module } from '@nestjs/common';
 import { MysqlService } from './mysql.service';
 
-@Module({
-  providers: [MysqlService]
-})
+@Module({ providers: [MysqlService] })
 export class MysqlModule {}

--- a/src/mysql/mysql.service.ts
+++ b/src/mysql/mysql.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { TypeOrmModuleOptions, TypeOrmOptionsFactory } from '@nestjs/typeorm'
+
+@Injectable()
+export class MysqlService implements TypeOrmOptionsFactory {
+  constructor(private configService: ConfigService) {}
+
+  createTypeOrmOptions(
+    connectionName?: string,
+  ): TypeOrmModuleOptions | Promise<TypeOrmModuleOptions> {
+    return {
+      type: 'mysql',
+      host: this.configService.get('DB_HOST'),
+      port: this.configService.get('DB_PORT'),
+      username: this.configService.get('DB_USER'),
+      password: this.configService.get('DB_PWD'),
+      database: this.configService.get('DB_NAME'),
+      entities: [__dirname + '/../**/*.entity.{ts,js}'],
+      synchronize: process.env.NODE_ENV !== 'production',
+      logging: process.env.NODE_ENV !== 'production',
+      charset: 'utf8mb4',
+    }
+  }
+}

--- a/src/mysql/mysql.service.ts
+++ b/src/mysql/mysql.service.ts
@@ -1,6 +1,6 @@
-import { Injectable } from '@nestjs/common'
-import { ConfigService } from '@nestjs/config'
-import { TypeOrmModuleOptions, TypeOrmOptionsFactory } from '@nestjs/typeorm'
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { TypeOrmModuleOptions, TypeOrmOptionsFactory } from '@nestjs/typeorm';
 
 @Injectable()
 export class MysqlService implements TypeOrmOptionsFactory {
@@ -20,6 +20,6 @@ export class MysqlService implements TypeOrmOptionsFactory {
       synchronize: process.env.NODE_ENV !== 'production',
       logging: process.env.NODE_ENV !== 'production',
       charset: 'utf8mb4',
-    }
+    };
   }
 }


### PR DESCRIPTION
이슈: #1 

## 1. mysql 커넥션 모듈생성 
- path: `/src/mysql/`
- aws rds 인스턴스는 아직 사용하기에는 이르며, 지원님과 접점이 생기게되면 그때 할 예정.
- 현재는 접점이 생기기전에는 `localhost:3306` 으로 각자의 로컬에서 database connection으로 실행해본다.
- **만일 로컬호스트로 데이터베이스 커넥션이 존재하지 않는다면 코멘트로 문의해주세요!**

## 2. 로그기록을 위한 미들웨어 생성
- path: `/src/loggers/`

## 3. swagger 라우터 url 변경
- (before) `/api` => (after) `/swagger`

## 4. 기본포트번호: 3000번으로 변경하였고, ConfigModule에 database관련 옵션 추가
## 5. `.prettierrc` 파일 내용에 옵션추가 : "endOfLine" : "auto" 로 변경
- 이유: windows os의 경우에는 endOfLine 이 LF가 아닌 CSRF를 기본으로한다. (반면 macOS는 LF를 지원한다) 운영체제 종류에 상관없이 포맷팅을 호환할수 있도록하기 위함이다.


### 추신

동작을 확인하려면 .env 파일에 값을 변경해야합니다. .env파일 값은 아래 링크를 참고하시면 됩니다.
https://discord.com/channels/1086624932009627729/1089898822529994773/1090648870364647445