### PR TITLE
[Hot-Fix] CORS 오류 수정 - 소셜연동로그인 (#43)

### DIFF
--- a/src/commons/middlewares/access-control-allow-origin.middleware.ts
+++ b/src/commons/middlewares/access-control-allow-origin.middleware.ts
@@ -1,14 +1,10 @@
 import { Request, Response, NextFunction } from 'express';
 import { Injectable, NestMiddleware } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class AccessControlAllowOriginMiddleware implements NestMiddleware {
-  constructor(private readonly configService: ConfigService) {}
-
   use(req: Request, res: Response, next: NextFunction) {
-    const frontendUrl = this.configService.get('FRONTEND_URL');
-    res.setHeader('Access-Control-Allow-Origin', frontendUrl);
+    res.setHeader('Access-Control-Allow-Origin', '*');
     next();
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,11 +38,15 @@ async function bootstrap() {
   // swagger을 제외한 모든 API는 맨앞에 '/api'를 붙인다.
   app.setGlobalPrefix('/api');
 
-
   // cors 설정
   const configService = app.get(ConfigService);
+  const corsOriginURLs = [
+    configService.get('FRONTEND_URL'),
+    'https://accounts.google.com',
+    'https://accounts.kakao.com',
+  ];
   app.enableCors({
-    origin: configService.get('FRONTEND_URL'),
+    origin: corsOriginURLs,
   });
 
   await app.listen(PORT, () => {


### PR DESCRIPTION
cors origin 에 카카오/구글 연동로그인시 로그인화면으로 진입 url 추가